### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:allowBackup="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme" 
+        android:requestLegacyExternalStorage="true">
 
         <service
             android:name=".WifiSyncService"


### PR DESCRIPTION
The android:requestLegacyExternalStorage="true" added to the application tag should fix access to stats.xml for ggmp syncing